### PR TITLE
Enabled Azure OpenAI+Streamable HTTP+Support for llama-cpp-python+SQLite Integration

### DIFF
--- a/src/xiyan_mcp_server/local_model/README.md
+++ b/src/xiyan_mcp_server/local_model/README.md
@@ -2,7 +2,7 @@
 Note: the local model is slow (about 12 seconds per query on my macbook).
 If you need a stable and fast service, we still recommend to use the modelscope version.
 
-To run xiyan_mcp_server in local mode, you need 
+To run xiyan_mcp_server in local mode, you need
 1) a PC/Mac/Machine with at least 16GB RAM
 2) 6GB disk space
 
@@ -21,7 +21,7 @@ modelscope download --model XGenerationLab/XiYanSQL-QwenCoder-3B-2502
 ```
 It will take you 6GB disk space.
 
-### Step 3: download the script and run server. 
+### Step 3: download the script and run server.
 
 Script is located at `src/xiyan_mcp_server/local_model/local_xiyan_server.py`
 
@@ -40,3 +40,42 @@ model:
 ```
 
 Till now the local model is ready.
+
+## LLama Cpp configuration
+
+### Model Source:
+
+Download the model from [mradermacher/XiYanSQL-QwenCoder-3B-2504-GGUF](https://huggingface.co/mradermacher/XiYanSQL-QwenCoder-3B-2504-GGUF). In this case, Q8_0 (size 3.4GB) was used.
+
+### Running the server
+
+1. Install required packages
+```
+#for Mac; Check llama-cpp-python documentation for other CMAKE_ARGS
+CMAKE_ARGS="-DGGML_METAL=on" uv pip install llama-cpp-python
+uv pip install Flask
+```
+
+2. Specify the path of the downloaded model in `MODEL_PATH` variable in `src/xiyan_mcp_server/local_model/llama_cpp_server.py`.
+
+3. Run the script: `uv run  src/xiyan_mcp_server/local_model/llama_cpp_server.py`
+
+### Configuration:
+
+```yml
+model:
+  name: "xiyan-llama-cpp" #any name will work
+  key: ""
+  url: "http://127.0.0.1:5090"
+```
+
+Now, run the xiyan mcp server and verify with mcp inspector.
+
+For Mac Pro M3, RAM: 24 GB:
+
+```
+llama_perf_context_print:        load time =    3652.49 ms
+llama_perf_context_print: prompt eval time =    3472.98 ms /  1502 tokens (    2.31 ms per token,   432.48 tokens per second)
+llama_perf_context_print:        eval time =    3711.96 ms /    85 runs   (   43.67 ms per token,    22.90 tokens per second)
+llama_perf_context_print:       total time =    7202.74 ms /  1587 tokens
+```

--- a/src/xiyan_mcp_server/local_model/llama_cpp_server.py
+++ b/src/xiyan_mcp_server/local_model/llama_cpp_server.py
@@ -1,0 +1,126 @@
+# main.py
+import os
+import time
+
+from flask import Flask, jsonify, request
+from llama_cpp import Llama
+
+# --- Configuration ---
+# IMPORTANT: Update this path to where you have stored your GGUF model file
+MODEL_PATH = "XiYanSQL-QwenCoder-3B-2504.Q8_0.gguf"
+
+# Set to a positive number to offload layers to the GPU.
+# Use 0 to disable GPU and run on CPU only.
+# Use -1 to offload all possible layers to the GPU.
+N_GPU_LAYERS = -1
+
+# --- End Configuration ---
+
+
+# Initialize the Flask app
+app = Flask(__name__)
+
+# --- Model Loading ---
+# Check if the model path is valid before starting the server
+if not os.path.exists(MODEL_PATH):
+    print(f"Error: Model file not found at '{MODEL_PATH}'")
+    print(
+        "Please update the MODEL_PATH variable in the script to the correct location of your GGUF model."
+    )
+    exit()
+
+print("Loading model... This may take a few minutes.")
+# Initialize the Llama model from the path
+# This will offload layers to the Metal GPU on your M3 Mac
+llm = Llama(
+    model_path=MODEL_PATH,
+    n_gpu_layers=N_GPU_LAYERS,
+    n_ctx=32768,  # Context window size
+    verbose=False,  # Set to True to see more detailed output from llama.cpp
+)
+print("Model loaded successfully.")
+
+# Get the model name from the file path for the response
+model_name = os.path.basename(MODEL_PATH)
+
+
+# --- API Endpoint ---
+@app.route("/chat/completions", methods=["POST"])
+def chat_completions():
+    """
+    Handles chat completion requests, compatible with OpenAI's API structure.
+    """
+    try:
+        # Get the JSON data from the request
+        input_data = request.json
+
+        # Extract parameters from the request
+        messages = input_data.get("messages", [])
+        temperature = input_data.get("temperature", 0.1)
+        max_tokens = input_data.get("max_tokens", 1024)
+
+        if not messages:
+            return jsonify(
+                {"error": "Request body must contain a 'messages' list."}
+            ), 400
+
+        print(
+            f"\nReceived prompt. Generating completion for model: {model_name}."
+        )
+
+        # Call the Llama model to create a chat completion
+        completion = llm.create_chat_completion(
+            messages=messages,
+            temperature=temperature,
+            max_tokens=max_tokens,
+            stream=False,
+            top_p=0.8,
+        )
+
+        # Add a check to ensure the response from the model is valid before processing
+        if (
+            not isinstance(completion, dict)
+            or "choices" not in completion
+            or len(completion.get("choices", [])) == 0
+        ):
+            error_message = f"Error: Invalid or empty response from model. Response: {completion}"
+            print(error_message)
+            return jsonify(
+                {"error": "Failed to get a valid response from the model."}
+            ), 500
+
+        # The generated text is inside the 'choices' list in the response
+        generated_text = completion["choices"][0]["message"]["content"]
+
+        # Format the response to match the OpenAI API structure
+        response = {
+            "id": completion.get("id", f"chatcmpl-{int(time.time())}"),
+            "object": "chat.completion",
+            "created": completion.get("created", int(time.time())),
+            "model": model_name,
+            "choices": [
+                {
+                    "index": 0,
+                    "message": {
+                        "role": "assistant",
+                        "content": generated_text,
+                    },
+                    "finish_reason": "stop",
+                }
+            ],
+            "usage": completion.get("usage"),
+        }
+
+        print(f"Generated Text: {generated_text}")
+        return jsonify(response)
+
+    except Exception as e:
+        print(f"An error occurred: {e}")
+        return jsonify({"error": "An internal server error occurred."}), 500
+
+
+# --- Main Execution ---
+if __name__ == "__main__":
+    # Note: This is a development server. For production, use a proper WSGI server like Gunicorn.
+    print("Starting Flask server on http://0.0.0.0:5090")
+    app.run(host="0.0.0.0", port=5090, debug=False)

--- a/src/xiyan_mcp_server/server.py
+++ b/src/xiyan_mcp_server/server.py
@@ -1,6 +1,8 @@
 import argparse
 import logging
 import os
+import signal
+import sys
 
 import yaml  # 添加yaml库导入
 from mcp.server import FastMCP
@@ -20,6 +22,15 @@ logging.basicConfig(
     format="%(asctime)s - %(name)s - %(levelname)s - %(message)s",
 )
 logger = logging.getLogger("xiyan_mcp_server")
+
+
+# Handle SIGINT (Ctrl+C) gracefully
+def signal_handler(sig, frame):
+    print("Shutting down server gracefully...")
+    sys.exit(0)
+
+
+signal.signal(signal.SIGINT, signal_handler)
 
 
 def get_yml_config():
@@ -113,6 +124,7 @@ def sql_gen_and_execute(db_env: DataBaseEnv, query: str):
         "messages": messages,
         "key": model_config["key"],
         "url": model_config["url"],
+        "api_version": model_config.get("api_version"),
     }
 
     try:
@@ -229,6 +241,7 @@ def main():
     if args.transport == "streamable-http":
         mcp.settings.port = args.port
         mcp.settings.host = args.host
+        logger.info(f"MCP server running at {args.host}/{args.port}")
         mcp.run(transport="streamable-http")
     else:
         mcp.run(transport=args.transport)

--- a/src/xiyan_mcp_server/server.py
+++ b/src/xiyan_mcp_server/server.py
@@ -1,36 +1,34 @@
 import argparse
 import logging
 import os
-from typing import Literal
+
 import yaml  # 添加yaml库导入
-
-from mysql.connector import connect, Error
-from mcp.server import  FastMCP
+from mcp.server import FastMCP
 from mcp.types import TextContent
+from mysql.connector import Error, connect
 
-from .utils.db_config import DBConfig
 from .database_env import DataBaseEnv
+from .utils.db_config import DBConfig
 from .utils.db_source import HITLSQLDatabase
 from .utils.db_util import init_db_conn
 from .utils.file_util import extract_sql_from_qwen
 from .utils.llm_util import call_openai_sdk
 
-
-
-
 # Configure logging
 logging.basicConfig(
     level=logging.INFO,
-    format='%(asctime)s - %(name)s - %(levelname)s - %(message)s'
+    format="%(asctime)s - %(name)s - %(levelname)s - %(message)s",
 )
 logger = logging.getLogger("xiyan_mcp_server")
 
 
 def get_yml_config():
-    config_path = os.getenv("YML", os.path.join(os.path.dirname(__file__), "config_demo.yml"))
+    config_path = os.getenv(
+        "YML", os.path.join(os.path.dirname(__file__), "config_demo.yml")
+    )
     logger.info(f"Loading configuration from {config_path}")
     try:
-        with open(config_path, 'r') as file:
+        with open(config_path, "r") as file:
             config = yaml.safe_load(file)
         return config
     except FileNotFoundError:
@@ -41,33 +39,38 @@ def get_yml_config():
         raise
 
 
-
 def get_xiyan_config(db_config):
-    dialect = db_config.get('dialect','mysql')
-    xiyan_db_config = DBConfig(dialect=dialect,db_name=db_config['database'], user_name=db_config['user'], db_pwd=db_config['password'], db_host=db_config['host'], port=db_config['port'])
+    dialect = db_config.get("dialect", "mysql")
+    xiyan_db_config = DBConfig(
+        dialect=dialect,
+        db_name=db_config["database"],
+        user_name=db_config["user"],
+        db_pwd=db_config["password"],
+        db_host=db_config["host"],
+        port=db_config["port"],
+    )
     return xiyan_db_config
 
 
 global_config = get_yml_config()
-mcp_config = global_config.get('mcp', {})
-model_config = global_config['model']
-global_db_config = global_config.get('database')
+mcp_config = global_config.get("mcp", {})
+model_config = global_config["model"]
+global_db_config = global_config.get("database")
 global_xiyan_db_config = get_xiyan_config(global_db_config)
-dialect = global_db_config.get('dialect','mysql')
-
+dialect = global_db_config.get("dialect", "mysql")
 
 
 mcp = FastMCP("xiyan", **mcp_config)
 
 
-@mcp.resource(dialect+'://'+global_db_config.get('database',''))
+@mcp.resource(dialect + "://" + global_db_config.get("database", ""))
 async def read_resource() -> str:
-
     db_engine = init_db_conn(global_xiyan_db_config)
     db_source = HITLSQLDatabase(db_engine)
     return db_source.mschema.to_mschema()
 
-@mcp.resource(dialect+"://{table_name}")
+
+@mcp.resource(dialect + "://{table_name}")
 async def read_resource(table_name) -> str:
     """Read table contents."""
     config = global_db_config
@@ -79,7 +82,7 @@ async def read_resource(table_name) -> str:
                 rows = cursor.fetchall()
                 result = [",".join(map(str, row)) for row in rows]
                 return "\n".join([",".join(columns)] + result)
-                
+
     except Error as e:
         raise RuntimeError(f"Database error: {str(e)}")
 
@@ -91,7 +94,7 @@ def sql_gen_and_execute(db_env: DataBaseEnv, query: str):
         query: natural language to query the database. e.g. 查询在2024年每个月，卡宴的各经销商销量分别是多少
     """
 
-    #db_env = context_variables.get('db_env', None)
+    # db_env = context_variables.get('db_env', None)
     prompt = f"""你现在是一名{db_env.dialect}数据分析专家，你的任务是根据参考的数据库schema和用户的问题，编写正确的SQL来回答用户的问题，生成的SQL用``sql 和```包围起来。
 【数据库schema】
 {db_env.mschema_str}
@@ -99,13 +102,18 @@ def sql_gen_and_execute(db_env: DataBaseEnv, query: str):
 【问题】
 {query}
 """
-    #logger.info(f"SQL generation prompt: {prompt}")
+    # logger.info(f"SQL generation prompt: {prompt}")
 
     messages = [
         {"role": "system", "content": prompt},
-        {"role": "user", "content": f"用户的问题是: {query}"}
+        {"role": "user", "content": f"用户的问题是: {query}"},
     ]
-    param = {"model": model_config['name'], "messages": messages,"key":model_config['key'],"url":model_config['url']}
+    param = {
+        "model": model_config["name"],
+        "messages": messages,
+        "key": model_config["key"],
+        "url": model_config["url"],
+    }
 
     try:
         response = call_openai_sdk(**param)
@@ -114,12 +122,14 @@ def sql_gen_and_execute(db_env: DataBaseEnv, query: str):
         status, res = db_env.database.fetch(sql_query)
         if not status:
             for idx in range(3):
-                sql_query = sql_fix(db_env.dialect, db_env.mschema_str, query, sql_query, res)
+                sql_query = sql_fix(
+                    db_env.dialect, db_env.mschema_str, query, sql_query, res
+                )
                 status, res = db_env.database.fetch(sql_query)
                 if status:
                     break
 
-        sql_res = db_env.database.fetch_truncated(sql_query,max_rows=100)
+        sql_res = db_env.database.fetch_truncated(sql_query, max_rows=100)
         markdown_res = db_env.database.trunc_result_to_markdown(sql_res)
         logger.info(f"SQL query: {sql_query}\nSQL result: {sql_res}")
         return markdown_res.strip()
@@ -128,29 +138,36 @@ def sql_gen_and_execute(db_env: DataBaseEnv, query: str):
         return str(e)
 
 
-def sql_fix(dialect: str, mschema: str, query: str, sql_query: str, error_info: str):
-    system_prompt = '''现在你是一个{dialect}数据分析专家，需要阅读一个客户的问题，参考的数据库schema，该问题对应的待检查SQL，以及执行该SQL时数据库返回的语法错误，请你仅针对其中的语法错误进行修复，输出修复后的SQL。
+def sql_fix(
+    dialect: str, mschema: str, query: str, sql_query: str, error_info: str
+):
+    system_prompt = """现在你是一个{dialect}数据分析专家，需要阅读一个客户的问题，参考的数据库schema，该问题对应的待检查SQL，以及执行该SQL时数据库返回的语法错误，请你仅针对其中的语法错误进行修复，输出修复后的SQL。
 注意：
 1、仅修复语法错误，不允许改变SQL的逻辑。
 2、生成的SQL用```sql 和```包围起来。
 
 【数据库schema】
 {schema}
-'''.format(dialect=dialect, schema=mschema)
-    user_prompt = '''【问题】
+""".format(dialect=dialect, schema=mschema)
+    user_prompt = """【问题】
 {question}
 
 【待检查SQL】
 {sql}
 
 【错误信息】
-{sql_res}'''.format(question=query, sql=sql_query, sql_res=error_info)
+{sql_res}""".format(question=query, sql=sql_query, sql_res=error_info)
 
     messages = [
         {"role": "system", "content": system_prompt},
-        {"role": "user", "content": user_prompt}
+        {"role": "user", "content": user_prompt},
     ]
-    param = {"model": model_config['name'], "messages": messages,"key":model_config['key'],'url':model_config['url']}
+    param = {
+        "model": model_config["name"],
+        "messages": messages,
+        "key": model_config["key"],
+        "url": model_config["url"],
+    }
 
     response = call_openai_sdk(**param)
     content = response.choices[0].message.content
@@ -158,7 +175,8 @@ def sql_fix(dialect: str, mschema: str, query: str, sql_query: str, error_info: 
 
     return sql_query
 
-def call_xiyan(query: str)-> str:
+
+def call_xiyan(query: str) -> str:
     """Fetch the data from database through a natural language query
 
     Args:
@@ -169,33 +187,52 @@ def call_xiyan(query: str)-> str:
     try:
         db_engine = init_db_conn(global_xiyan_db_config)
         db_source = HITLSQLDatabase(db_engine)
-    except Exception as  e:
-
-        return "数据库连接失败"+str(e)
-    logger.info(f"Calling xiyan")
+    except Exception as e:
+        return "数据库连接失败" + str(e)
+    logger.info("Calling xiyan")
     env = DataBaseEnv(db_source)
-    res = sql_gen_and_execute(env,query)
+    res = sql_gen_and_execute(env, query)
 
     return str(res)
+
+
 @mcp.tool()
-def get_data(query: str)-> list[TextContent]:
+def get_data(query: str) -> list[TextContent]:
     """Fetch the data from database through a natural language query
 
     Args:
         query: The query in natural language
     """
 
-    res=call_xiyan(query)
+    res = call_xiyan(query)
     return [TextContent(type="text", text=res)]
-
 
 
 def main():
     parser = argparse.ArgumentParser(description="Run MCP server.")
-    parser.add_argument('transport', nargs='?', default='stdio', choices=['stdio', 'sse'],
-                        help='Transport type (stdio or sse)')
+    parser.add_argument(
+        "transport",
+        nargs="?",
+        default="stdio",
+        choices=["stdio", "streamable-http", "sse"],
+        help="Transport type (stdio, streamable-http or sse)",
+    )
+    parser.add_argument(
+        "host", default="localhost", help="host for the http transport"
+    )
+
+    parser.add_argument(
+        "port", default="8000", help="port for the http transport"
+    )
     args = parser.parse_args()
-    mcp.run(transport=args.transport)
+
+    if args.transport == "streamable-http":
+        mcp.settings.port = args.port
+        mcp.settings.host = args.host
+        mcp.run(transport="streamable-http")
+    else:
+        mcp.run(transport=args.transport)
+
 
 if __name__ == "__main__":
     main()

--- a/src/xiyan_mcp_server/utils/llm_util.py
+++ b/src/xiyan_mcp_server/utils/llm_util.py
@@ -15,7 +15,7 @@ def call_openai_sdk(**args):
             azure_endpoint=base_url,
             azure_deployment=args.get("model", "gpt-35-turbo"),
         )
-        logging.error("Configured Azure Chat Open AI")
+        logging.info("Configured AzureOpenAI")
     else:
         client = OpenAI(
             api_key=key,

--- a/src/xiyan_mcp_server/utils/llm_util.py
+++ b/src/xiyan_mcp_server/utils/llm_util.py
@@ -1,17 +1,28 @@
-from openai import OpenAI
+import logging
+
+from openai import AzureOpenAI, OpenAI
 
 
 def call_openai_sdk(**args):
-    key = args['key']
-    base_url = args['url']
-    client = OpenAI(
-        api_key=key,
-        base_url=base_url,
-    )
-    del args['key']
-    del args['url']
-    completion = client.chat.completions.create(
-        **args
-    )
-    return completion
+    key = args["key"]
+    base_url = args["url"]
 
+    if "azure" in base_url:
+        api_version = args.get("api_version", "2025-01-01-preview")
+        client = AzureOpenAI(
+            api_version=api_version,
+            api_key=key,
+            azure_endpoint=base_url,
+            azure_deployment=args.get("model", "gpt-35-turbo"),
+        )
+        logging.error("Configured Azure Chat Open AI")
+    else:
+        client = OpenAI(
+            api_key=key,
+            base_url=base_url,
+        )
+    del args["key"]
+    del args["url"]
+    del args["api_version"]
+    completion = client.chat.completions.create(**args)
+    return completion


### PR DESCRIPTION
## Addition of Streamable HTTP:
1. Added two arguments: host, port for choosing respective values
2. Default values are localhost, 8000 respectively
3. Example configuration:
```yml
 mcp:
   transport: "streamable-http"
   port: 8000
   log_level: "DEBUG"
 ```
 
 ## Usage of Azure Open AI:
 Implemented in the method `call_openai_sdk` from `src/xiyan_mcp_server/utils/llm_util.py`: No change anywhere else is required
 Example Configuration:
 ```yml
 model:
  name: "gpt-4o"
  key: "my api key"
  url: "endpoint url"
  api_version: "2025-01-01-preview" #this is the default value
 ```
 
 ## llama-cpp-python

Local model supported by llama-cpp-python can now be used.

## Enabled SQlite through config:

```yml
database:
  dialect: "sqlite"
  db_path: "/absolute/path/to/sqlite.db"
 ```