### PR TITLE
docs: add Fronteir AI hosted deployment option

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,10 @@
 - 🖱️ List available tables as resources
 - 🔧 Read table contents
 
+## Hosted deployment
+
+A hosted deployment is available on [Fronteir AI](https://fronteir.ai/mcp/xgenerationlab-xiyan-mcp-server).
+
 ## Preview
 ### Architecture
 There are two ways to integrate this server in your project, as shown below:


### PR DESCRIPTION
Love the project!

Adds a short note in the README that a hosted deployment is available on [Fronteir AI](https://fronteir.ai/mcp/xgenerationlab-xiyan-mcp-server).